### PR TITLE
Adapt repository to FreeCAD AddonManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# v0.1.0 - 2025-05-22 - First Release
+
+This is the very first release of the AssemblyExportToMuJoCo FreeCAD Macro.
+
+## Features
+
+- Support for Grounded, Fixed and Revolute joints.
+- Dockable panel in FreeCAD's task panel for configuration.

--- a/README.md
+++ b/README.md
@@ -4,23 +4,42 @@
 <img src="AssemblyExportToMuJoCo.svg" width="200px"/>
 </div>
 
-This repository contains a [FreeCAD](https://www.freecad.org/) macro to export an Assembly made with the builtin [Assembly Workbench](https://wiki.freecad.org/Assembly_Workbench) to [MuJoCo](https://mujoco.org/).
+This is a [FreeCAD](https://www.freecad.org/) macro to export an Assembly made with the builtin [Assembly Workbench](https://wiki.freecad.org/Assembly_Workbench) to [MuJoCo](https://mujoco.org/).
+
+<p align="center">
+    <img src="examples/universal_joint/output.gif"/>
+    <br>
+    <em>Export of universal joint assembly to MuJoCo</em>
+</p>
+
+If you find any bugs while using the macro, please feel free to open an [issue](https://github.com/AnesBenmerzoug/FreeCAD-Macro-AssemblyExportToMuJoCo/issues).
+
+## Changelog
+
+A log of all notables changes made to the macro can be found [here.](CHANGELOG.md)
 
 ## Prerequisites
 
-- Python >= 3.10
-- FreeCAD >= 1.0
+- Python >= 3.10.0
+- FreeCAD >= 1.0.0
 
-## Getting Started
+## Installation
+
+### Manual Installation
 
 - [Install the Macro](https://wiki.freecad.org/How_to_install_macros) manually in FreeCAD by copying
-  the [AssemblyExportToMuJoCo.FCMacro](./AssemblyExportToMuJoCo.FCMacro) and [AssemblyExportToMuJoCo.svg](./AssemblyExportToMuJoCo.svg) files into FreeCAD's Macro directory.
+  the following files into FreeCAD's Macro directory:
+  
+  - [AssemblyExportToMuJoCo.FCMacro](./AssemblyExportToMuJoCo.FCMacro) 
+  - [AssemblyExportToMuJoCo.svg](./AssemblyExportToMuJoCo.svg) 
 
 - (Optional) Add the Macro to the toolbar for easier execution.
 
 - Open the assembly you want to export into MuJoCo.
 
 - Select it and execute the Macro.
+
+## Simulating the export with MuJoCo
 
 - [Install MuJoCo](https://mujoco.readthedocs.io/en/latest/programming/#getting-started)
 
@@ -43,8 +62,7 @@ This repository contains a [FreeCAD](https://www.freecad.org/) macro to export a
 
 ## Examples
 
-Please refer to the [examples](examples/) directory for some examples showcasing this macro.
-
+Please refer to the [examples](examples/) directory for some examples showcasing the use of this macro.
 
 ## Troubleshooting
 

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+
+    <name>Assembly Export to MuJoCo</name>
+    <description>An addon that contains a macro for exporting FreeCAD builtin Assemblies to MuJoCo.</description>
+    <icon>resources/icons/AssemblyExportToMuJoCo.svg</icon>
+    <version>0.1.0</version>
+    <date>2025-05-31</date>
+    
+    <author email="anes.benmerzoug@gmail.com">Anes Benmerzoug</author>
+    <maintainer email="anes.benmerzoug@gmail.com">Anes Benmerzoug</maintainer>
+    <license file="LICENSE">LGPL-2.1-or-later</license>
+
+    <url branch="main" type="repository">https://github.com/AnesBenmerzoug/FreeCAD-Macro-AssemblyExportToMuJoCo</url>
+    <url type="bugtracker">https://github.com/AnesBenmerzoug/FreeCAD-Macro-AssemblyExportToMuJoCo/issues</url>
+    <url type="readme">https://github.com/AnesBenmerzoug/FreeCAD-Macro-AssemblyExportToMuJoCo/blob/main/README.md</url>
+
+    <content>
+        <macro>
+            <description>A macro for exporting FreeCAD builtin Assemblies to MuJoCo.</description>
+            <freecadmin>1.0.0</freecadmin>
+            <python_min>3.10.0</python_min>
+            <icon>../resources/icons/AssemblyExportToMuJoCo.svg</icon>
+            <subdirectory>./src</subdirectory>
+            <file>AssemblyExportToMuJoCo.FCMacro</file>
+            <tag>Assembly</tag>
+            <tag>MuJoCo</tag>
+            <tag>export</tag>
+            <tag>simulation</tag>
+        </macro>
+    </content>
+
+</package>


### PR DESCRIPTION
This PR adapts the repository so that the macro can be installed through the Addon Manager (See #1)