### PR TITLE
Assembly2MuJoCo: update icon path in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
 
     <name>Assembly2MuJoCo</name>
     <description>An addon for exporting FreeCAD builtin Assemblies to MuJoCo.</description>
-    <icon>freecad/assembly2mujoco/resources/icons/assembly2mujoco-icon.svg</icon>
+    <icon>resources/icons/assembly2mujoco-icon.svg</icon>
     <version>0.2.0</version>
     <date>2025-06-08</date>
 


### PR DESCRIPTION
Fix `<icon>` path so it matches [the icon resource](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/blob/dev/resources/icons/assembly2mujoco-icon.svg).