### PR TITLE
Test freecad version 1.1dev in CI

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -17,7 +17,7 @@ runs:
       environment-file: environment.yml
       create-args: >-
         python=${{ inputs.python_version }}
-        freecad::freecad=${{ inputs.freecad_version }}
+        freecad=${{ inputs.freecad_version }}
       init-shell: bash
       cache-environment: true
       post-cleanup: 'all'

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -17,7 +17,7 @@ runs:
       environment-file: environment.yml
       create-args: >-
         python=${{ inputs.python_version }}
-        freecad=${{ inputs.freecad_version }}
+        freecad::freecad=${{ inputs.freecad_version }}
       init-shell: bash
       cache-environment: true
       post-cleanup: 'all'

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Setup and Cache Conda Environment with FreeCAD
+  - name: Setup and Cache Conda Environment with Python=${{ inputs.python_version }} and FreeCAD=${{ inputs.freecad_version }}
     uses: mamba-org/setup-micromamba@v2
     with:
       environment-file: environment.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,16 +28,29 @@ defaults:
     shell: bash -el {0}
 
 jobs:
+  setup:
+    name: Matrix Variables Setup
+    runs-on: ubuntu-latest
+    outputs:
+      python_versions: ${{ steps.set-matrix.outputs.python_versions }}
+      freecad_versions: ${{ steps.set-matrix.outputs.freecad_versions }}
+    steps:
+      - id: set-matrix
+        run: |
+          echo 'python_versions=${{ env.PYTHON_VERSIONS }}' >> $GITHUB_OUTPUT
+          echo 'freecad_versions=${{ env.FREECAD_VERSIONS }}' >> $GITHUB_OUTPUT
+
   code-quality:
     name: Lint and format code
     runs-on: ubuntu-latest
+    needs: setup
     steps:
     - uses: actions/checkout@v5
     - name: Setup Environment
       uses: ./.github/actions/environment
       with:
-        python_version: ${{ fromJson(env.PYTHON_VERSIONS)[0] }}
-        freecad_version: ${{ fromJson(env.FREECAD_VERSIONS)[0] }}
+        python_version: ${{ fromJson(needs.setup.outputs.python_versions)[0] }}
+        freecad_version: ${{ fromJson(needs.setup.outputs.freecad_versions)[0] }}
     - name: Cache pre-commit environments
       uses: actions/cache@v4
       with:
@@ -56,10 +69,11 @@ jobs:
   tests:
     name: Run tests
     runs-on: ubuntu-latest
+    needs: setup
     strategy:
       matrix:
-        python_version: ${{ fromJson(env.PYTHON_VERSIONS) }}
-        freecad_version: ${{ fromJson(env.FREECAD_VERSIONS) }}
+        python_version: ${{ fromJson(needs.setup.outputs.python_versions) }}
+        freecad_version: ${{ fromJson(needs.setup.outputs.python_versions) }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup Environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ env:
   GITHUB_BOT_USERNAME: github-actions[bot]
   GITHUB_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   PY_COLORS: 1
-  PYTHON_VERSIONS: '["3.11", "3.12"]'
+  PYTHON_VERSIONS: '["3.11"]'
   FREECAD_VERSIONS: '["1.0.2", "1.1dev"]'
 
 defaults:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ env:
   GITHUB_BOT_USERNAME: github-actions[bot]
   GITHUB_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   PY_COLORS: 1
-  PYTHON_VERSION: '3.11'
-  FREECAD_VERSION: '1.0.2'
+  PYTHON_VERSIONS: ['3.11', '3.12']
+  FREECAD_VERSIONS: ['1.0.2', '1.1dev']
 
 defaults:
   run:
@@ -36,8 +36,8 @@ jobs:
     - name: Setup Environment
       uses: ./.github/actions/environment
       with:
-        python_version: ${{ env.PYTHON_VERSION }}
-        freecad_version: ${{ env.FREECAD_VERSION }}
+        python_version: ${{ env.PYTHON_VERSIONS[0] }}
+        freecad_version: ${{ env.FREECAD_VERSIONS[0] }}
     - name: Cache pre-commit environments
       uses: actions/cache@v4
       with:
@@ -56,13 +56,17 @@ jobs:
   tests:
     name: Run tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ${{ env.PYTHON_VERSIONS }}
+        freecad_version: ${{ env.FREECAD_VERSIONS }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup Environment
         uses: ./.github/actions/environment
         with:
-          python_version: ${{ env.PYTHON_VERSION }}
-          freecad_version: ${{ env.FREECAD_VERSION }}
+          python_version: ${{ matrix.python_version }}
+          freecad_version: ${{ matrix.freecad_version }}
       - name: Run pytest
         id: pytest
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,7 @@ jobs:
     needs: setup
     strategy:
       matrix:
+        fail-fast: false
         python_version: ${{ fromJson(needs.setup.outputs.python_versions) }}
         freecad_version: ${{ fromJson(needs.setup.outputs.freecad_versions) }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
   GITHUB_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   PY_COLORS: 1
   PYTHON_VERSIONS: '["3.11", "3.12"]'
-  FREECAD_VERSION: '["1.0.2", "1.1dev"]'
+  FREECAD_VERSIONS: '["1.0.2", "1.1dev"]'
 
 defaults:
   run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,13 +32,30 @@ jobs:
     name: Matrix Variables Setup
     runs-on: ubuntu-latest
     outputs:
-      python_versions: ${{ steps.set-matrix.outputs.python_versions }}
-      freecad_versions: ${{ steps.set-matrix.outputs.freecad_versions }}
+      python_versions: ${{ steps.set_matrix.outputs.python_versions }}
+      freecad_versions: ${{ steps.set_matrix.outputs.freecad_versions }}
     steps:
-      - id: set-matrix
+      - name: Create Matrix
+        id: set_matrix
         run: |
           echo 'python_versions=${{ env.PYTHON_VERSIONS }}' >> $GITHUB_OUTPUT
           echo 'freecad_versions=${{ env.FREECAD_VERSIONS }}' >> $GITHUB_OUTPUT
+      - name: Generate Summary
+        run: |
+          echo "## Matrix Configuration" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Python Versions" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.set_matrix.outputs.python_versions }}' | jq -r '.[]' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### FreeCAD Versions" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.set_matrix.outputs.freecad_versions }}' | jq -r '.[]' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Total combinations:** $(($(echo '${{ steps.set_matrix.outputs.python_versions }}' | jq length) * $(echo '${{ steps.set_matrix.outputs.freecad_versions }}' | jq length)))" >> $GITHUB_STEP_SUMMARY
+
 
   code-quality:
     name: Lint and format code
@@ -73,7 +90,7 @@ jobs:
     strategy:
       matrix:
         python_version: ${{ fromJson(needs.setup.outputs.python_versions) }}
-        freecad_version: ${{ fromJson(needs.setup.outputs.python_versions) }}
+        freecad_version: ${{ fromJson(needs.setup.outputs.freecad_versions) }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup Environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ env:
   GITHUB_BOT_USERNAME: github-actions[bot]
   GITHUB_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   PY_COLORS: 1
-  PYTHON_VERSIONS: ['3.11', '3.12']
-  FREECAD_VERSIONS: ['1.0.2', '1.1dev']
+  PYTHON_VERSIONS: '["3.11", "3.12"]'
+  FREECAD_VERSION: '["1.0.2", "1.1dev"]'
 
 defaults:
   run:
@@ -36,8 +36,8 @@ jobs:
     - name: Setup Environment
       uses: ./.github/actions/environment
       with:
-        python_version: ${{ env.PYTHON_VERSIONS[0] }}
-        freecad_version: ${{ env.FREECAD_VERSIONS[0] }}
+        python_version: ${{ fromJson(env.PYTHON_VERSIONS)[0] }}
+        freecad_version: ${{ fromJson(env.FREECAD_VERSIONS)[0] }}
     - name: Cache pre-commit environments
       uses: actions/cache@v4
       with:
@@ -58,8 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ${{ env.PYTHON_VERSIONS }}
-        freecad_version: ${{ env.FREECAD_VERSIONS }}
+        python_version: ${{ fromJson(env.PYTHON_VERSIONS) }}
+        freecad_version: ${{ fromJson(env.FREECAD_VERSIONS) }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup Environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,6 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     needs: setup
-    continue-on-error: true
     strategy:
       matrix:
         python_version: ${{ fromJson(needs.setup.outputs.python_versions) }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,9 +87,9 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     needs: setup
+    continue-on-error: true
     strategy:
       matrix:
-        fail-fast: false
         python_version: ${{ fromJson(needs.setup.outputs.python_versions) }}
         freecad_version: ${{ fromJson(needs.setup.outputs.freecad_versions) }}
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
 name: freecad
 channels:
-- conda-forge
 - freecad
+- conda-forge
 dependencies:
-- python=3.11
-- freecad=1.0.2
+- python
+- freecad
 - pre-commit=4.2.*
 - mypy=1.16.*
 - pytest==8.4.*

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,8 @@ channels:
 - freecad
 - conda-forge
 dependencies:
-- python
-- freecad
+- python=3.11
+- freecad=1.0.2
 - pre-commit=4.2.*
 - mypy=1.16.*
 - pytest==8.4.*


### PR DESCRIPTION
This PR adds a matrix of different python and freecad versions to make sure that the tests still run.

Most importantly, I would like to make sure that the workbench will still work with the next version of FreeCAD.