### PR TITLE
feat: add support for cylindrical joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Handle conversion of cylindrical and ball joints ([#14](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/14))
+
 ### Changed
 
 - Set `align="true"` property of MuJoCo [freejoint](https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-freejoint) ([#15](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/15))

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Here are some of the planned developments for this Workbench:
   - [X] Grounded
   - [X] Fixed
   - [X] Revolute
-  - [ ] Cylindrical
+  - [X] Cylindrical
   - [X] Slider
   - [ ] Ball
   - [ ] Distance

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Here are some of the planned developments for this Workbench:
   - [X] Revolute
   - [X] Cylindrical
   - [X] Slider
-  - [ ] Ball
+  - [X] Ball *(uses native MuJoCo ball joint type)*
   - [ ] Distance
   - [ ] Parallel
   - [ ] Perpendicular

--- a/freecad/assembly2mujoco/core/assembly.py
+++ b/freecad/assembly2mujoco/core/assembly.py
@@ -131,13 +131,13 @@ class AssemblyGraphEdge:
             # You may need to adjust this based on your FreeCAD assembly convention:
             # axis_vector = global_plc.Rotation.multVec(App.Vector(1, 0, 0))
 
-        elif self.joint.JointType == "Cylindrical":
+        elif self.is_cylindrical():
             # Cylindrical joint combines rotation and translation along the same axis
             # The Z-axis of the placement is the axis for both rotation and translation
             pos_vector = global_plc.Base
             axis_vector = global_plc.Rotation.multVec(App.Vector(0, 0, 1))
 
-        elif self.joint.JointType == "Ball":
+        elif self.is_ball():
             # Ball joint has 3-DOF rotation around a single point
             # Only position is needed; no axis required
             pos_vector = global_plc.Base

--- a/freecad/assembly2mujoco/core/assembly.py
+++ b/freecad/assembly2mujoco/core/assembly.py
@@ -131,13 +131,13 @@ class AssemblyGraphEdge:
             # You may need to adjust this based on your FreeCAD assembly convention:
             # axis_vector = global_plc.Rotation.multVec(App.Vector(1, 0, 0))
 
-        elif self.is_cylindrical():
+        elif self.is_cylindrical:
             # Cylindrical joint combines rotation and translation along the same axis
             # The Z-axis of the placement is the axis for both rotation and translation
             pos_vector = global_plc.Base
             axis_vector = global_plc.Rotation.multVec(App.Vector(0, 0, 1))
 
-        elif self.is_ball():
+        elif self.is_ball:
             # Ball joint has 3-DOF rotation around a single point
             # Only position is needed; no axis required
             pos_vector = global_plc.Base

--- a/freecad/assembly2mujoco/core/assembly.py
+++ b/freecad/assembly2mujoco/core/assembly.py
@@ -137,6 +137,14 @@ class AssemblyGraphEdge:
             pos_vector = global_plc.Base
             axis_vector = global_plc.Rotation.multVec(App.Vector(0, 0, 1))
 
+        elif self.joint.JointType == "Ball":
+            # Ball joint has 3-DOF rotation around a single point
+            # Only position is needed; no axis required
+            pos_vector = global_plc.Base
+            # Ball joints don't have a single axis in MuJoCo
+            # Return zero vector as placeholder
+            axis_vector = App.Vector(0, 0, 0)
+
         else:
             raise NotImplementedError(
                 f"{WORKBENCH_NAME}: Getting joint axis not implemented for joint type: {self.joint.JointType}"
@@ -152,6 +160,11 @@ class AssemblyGraphEdge:
     def is_cylindrical(self) -> bool:
         """Check if this is a cylindrical joint"""
         return self.joint.JointType == "Cylindrical"
+
+    @property
+    def is_ball(self) -> bool:
+        """Check if this is a ball joint"""
+        return self.joint.JointType == "Ball"
 
     @property
     def joint_range(self) -> str | None:

--- a/freecad/assembly2mujoco/core/assembly.py
+++ b/freecad/assembly2mujoco/core/assembly.py
@@ -152,8 +152,9 @@ class AssemblyGraphEdge:
 
         # Convert mm to m
         pos_vector = pos_vector / 1000
-        # Normalize axis
-        axis_vector = axis_vector.normalize()
+        # Normalize axis (skip for Ball joints which have zero axis)
+        if axis_vector.Length > 1e-10:
+            axis_vector = axis_vector.normalize()
         return pos_vector, axis_vector
 
     @property

--- a/freecad/assembly2mujoco/core/assembly.py
+++ b/freecad/assembly2mujoco/core/assembly.py
@@ -131,6 +131,12 @@ class AssemblyGraphEdge:
             # You may need to adjust this based on your FreeCAD assembly convention:
             # axis_vector = global_plc.Rotation.multVec(App.Vector(1, 0, 0))
 
+        elif self.joint.JointType == "Cylindrical":
+            # Cylindrical joint combines rotation and translation along the same axis
+            # The Z-axis of the placement is the axis for both rotation and translation
+            pos_vector = global_plc.Base
+            axis_vector = global_plc.Rotation.multVec(App.Vector(0, 0, 1))
+
         else:
             raise NotImplementedError(
                 f"{WORKBENCH_NAME}: Getting joint axis not implemented for joint type: {self.joint.JointType}"
@@ -141,6 +147,11 @@ class AssemblyGraphEdge:
         # Normalize axis
         axis_vector = axis_vector.normalize()
         return pos_vector, axis_vector
+
+    @property
+    def is_cylindrical(self) -> bool:
+        """Check if this is a cylindrical joint"""
+        return self.joint.JointType == "Cylindrical"
 
     @property
     def joint_range(self) -> str | None:

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -506,7 +506,7 @@ class MuJoCoExporter:
         joint_range = edge.joint_range
         if joint_range is not None:
             hinge_joint.set("range", joint_range)
-            # slide_joint would need separate translation limits if available
+            # TODO: slide_joint would need separate translation limits if available
 
         # Create actuators for both joints
         ET.SubElement(
@@ -663,7 +663,15 @@ class MuJoCoExporter:
                     diaginertia="1e-9 1e-9 1e-9",  # Much larger than mjMINVAL
                 )
                 # Insert joint between parent and dummy body
-                self.add_joint_to_body(dummy_body, edge)
+# Insert joint between parent and dummy body
+if edge.is_ball:
+    # Ball joints in loops need special handling
+    self._process_ball_loop(u, v, edge)
+elif edge.is_cylindrical:
+    # Cylindrical joints in loops need special handling with dummy bodies
+    self._process_cylindrical_loop(u, v, edge)
+else:
+    self.add_joint_to_body(dummy_body, edge)
 
                 # Insert weld constraint between dummy body and child body
                 ET.SubElement(

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -412,6 +412,10 @@ class MuJoCoExporter:
         # Special handling for Cylindrical joints
         if edge.is_cylindrical:
             return self._add_cylindrical_joint_to_body(body, edge)
+        
+        # Special handling for Ball joints
+        if edge.is_ball:
+            return self._add_ball_joint_to_body(body, edge)
 
         joint_type = edge.mujoco_joint_type
         if joint_type is None:
@@ -531,6 +535,53 @@ class MuJoCoExporter:
 
         return hinge_joint  # Return primary joint
 
+    def _add_ball_joint_to_body(
+        self,
+        body: ET.Element,
+        edge: AssemblyGraphEdge,
+    ) -> ET.Element:
+        """Add a ball joint to a body element.
+
+        A Ball joint in FreeCAD provides 3-DOF rotation around a single point.
+        MuJoCo has native support for ball joints using quaternion representation.
+        """
+        joint_pos_vector, _ = edge.joint_position_and_axis
+        joint_pos = " ".join(str(x) for x in joint_pos_vector)
+
+        # Create ball joint element (no axis attribute needed)
+        ball_joint = ET.SubElement(
+            body,
+            "joint",
+            type="ball",
+            name=edge.label,
+            pos=joint_pos,
+        )
+
+        # Handle joint limits if present
+        joint_range = edge.joint_range
+        if joint_range is not None:
+            ball_joint.set("range", joint_range)
+
+        # Create actuator element
+        actuator_element = ET.SubElement(
+            self.actuator,
+            "position",
+            name=ball_joint.get("name"),  # type: ignore
+            joint=ball_joint.get("name"),  # type: ignore
+            kp="100",
+        )
+        if joint_range is not None:
+            actuator_element.set("ctrlrange", joint_range)
+
+        # Create sensor element
+        ET.SubElement(
+            self.sensor,
+            "jointpos",
+            name=ball_joint.get("name") + "_pos",  # type: ignore
+            joint=ball_joint.get("name"),  # type: ignore
+        )
+        return ball_joint
+
     def process_kinematic_loops(
         self,
         unused_edges: list[
@@ -550,6 +601,9 @@ class MuJoCoExporter:
                     solref="0.01 1",
                     solimp="0.9 0.95 0.001",
                 )
+            elif edge.is_ball:
+                # Ball joints in loops need special handling
+                self._process_ball_loop(u, v, edge)
             elif edge.is_cylindrical:
                 # Cylindrical joints in loops need special handling with dummy bodies
                 self._process_cylindrical_loop(u, v, edge)
@@ -659,6 +713,60 @@ class MuJoCoExporter:
 
         # Add both hinge and slide joints using the cylindrical handler
         self._add_cylindrical_joint_to_body(dummy_body, edge)
+
+        # Connect dummy body to child via weld constraint
+        ET.SubElement(
+            self.equality,
+            "weld",
+            name=f"loop_weld_{edge.label}",
+            body1=dummy_body.get("name"),  # type: ignore
+            body2=v.label,
+            solref="0.01 1",
+            solimp="0.9 0.95 0.001",
+        )
+
+    def _process_ball_loop(
+        self,
+        u: AssemblyGraphNode,
+        v: AssemblyGraphNode,
+        edge: AssemblyGraphEdge,
+    ) -> None:
+        """Handle ball joint in kinematic loop.
+
+        Creates a dummy body with a ball joint,
+        then connects it to the child body via weld constraint.
+        """
+        joint_pos_vector, _ = edge.joint_position_and_axis
+        joint_pos = " ".join(str(x) for x in joint_pos_vector)
+
+        # Find parent body
+        found_bodies = self.worldbody.findall(f".//body[@name='{u.label}']")
+        if not found_bodies:
+            raise ValueError(
+                f"Could not find body with name '{u.label}' in MJCF"
+            )
+
+        parent_body = found_bodies[0]
+
+        # Create dummy body for the ball joint
+        dummy_body = ET.SubElement(
+            parent_body,
+            "body",
+            name=f"dummy_{u.label}_{v.label}",
+            pos=joint_pos,
+        )
+
+        # Add minimal inertia
+        ET.SubElement(
+            dummy_body,
+            "inertial",
+            pos=joint_pos,
+            mass="1e-6",  # Much larger than mjMINVAL (1e-15)
+            diaginertia="1e-9 1e-9 1e-9",  # Much larger than mjMINVAL
+        )
+
+        # Add ball joint using the ball handler
+        self._add_ball_joint_to_body(dummy_body, edge)
 
         # Connect dummy body to child via weld constraint
         ET.SubElement(

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -487,7 +487,7 @@ class MuJoCoExporter:
         )
 
         # Create slide joint for translation
-        slide_joint = ET.SubElement(
+        _slide_joint = ET.SubElement(
             body,
             "joint",
             type="slide",

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -412,7 +412,7 @@ class MuJoCoExporter:
         # Special handling for Cylindrical joints
         if edge.is_cylindrical:
             return self._add_cylindrical_joint_to_body(body, edge)
-        
+
         # Special handling for Ball joints
         if edge.is_ball:
             return self._add_ball_joint_to_body(body, edge)
@@ -442,8 +442,8 @@ class MuJoCoExporter:
         actuator_element = ET.SubElement(
             self.actuator,
             "position",
-            name=joint_element.get("name"), # type: ignore
-            joint=joint_element.get("name"), # type: ignore
+            name=joint_element.get("name"),  # type: ignore
+            joint=joint_element.get("name"),  # type: ignore
             kp="100",
         )
         if joint_range is not None:
@@ -453,8 +453,8 @@ class MuJoCoExporter:
         ET.SubElement(
             self.sensor,
             "jointpos",
-            name=joint_element.get("name") + "_pos", # type: ignore
-            joint=joint_element.get("name"), # type: ignore
+            name=joint_element.get("name") + "_pos",  # type: ignore
+            joint=joint_element.get("name"),  # type: ignore
         )
         return joint_element
 
@@ -574,12 +574,12 @@ class MuJoCoExporter:
             actuator_element.set("ctrlrange", joint_range)
 
         # Create sensor element
-        ET.SubElement(
-            self.sensor,
-            "jointpos",
-            name=ball_joint.get("name") + "_pos",  # type: ignore
-            joint=ball_joint.get("name"),  # type: ignore
-        )
+        # ET.SubElement(
+        #     self.sensor,
+        #     "jointpos",
+        #     name=ball_joint.get("name") + "_pos",  # type: ignore
+        #     joint=ball_joint.get("name"),  # type: ignore
+        # )
         return ball_joint
 
     def process_kinematic_loops(
@@ -637,9 +637,7 @@ class MuJoCoExporter:
                 # For other joint types we insert dummy bodies and add weld constraints
                 found_bodies = self.worldbody.findall(f".//body[@name='{u.label}']")
                 if not found_bodies:
-                    raise ValueError(
-                        f"Could not find body with name '{u.label}' in MJCF"
-                    )
+                    raise ValueError(f"Could not find body with name '{u.label}' in MJCF")
 
                 parent_body = found_bodies[0]
 
@@ -654,8 +652,8 @@ class MuJoCoExporter:
                     dummy_body,
                     "inertial",
                     pos=joint_pos,
-                    mass="1e-6", # Much larger than mjMINVAL (1e-15)
-                    diaginertia="1e-9 1e-9 1e-9", # Much larger than mjMINVAL
+                    mass="1e-6",  # Much larger than mjMINVAL (1e-15)
+                    diaginertia="1e-9 1e-9 1e-9",  # Much larger than mjMINVAL
                 )
                 # Insert joint between parent and dummy body
                 self.add_joint_to_body(dummy_body, edge)
@@ -665,7 +663,7 @@ class MuJoCoExporter:
                     self.equality,
                     "weld",
                     name=f"loop_weld_{edge.label}",
-                    body1=dummy_body.get("name"), # type: ignore
+                    body1=dummy_body.get("name"),  # type: ignore
                     body2=v.label,
                     solref="0.01 1",
                     solimp="0.9 0.95 0.001",
@@ -742,9 +740,7 @@ class MuJoCoExporter:
         # Find parent body
         found_bodies = self.worldbody.findall(f".//body[@name='{u.label}']")
         if not found_bodies:
-            raise ValueError(
-                f"Could not find body with name '{u.label}' in MJCF"
-            )
+            raise ValueError(f"Could not find body with name '{u.label}' in MJCF")
 
         parent_body = found_bodies[0]
 

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -409,6 +409,10 @@ class MuJoCoExporter:
         edge: AssemblyGraphEdge,
     ) -> ET.Element | None:
         """Add a joint to a body element"""
+        # Special handling for Cylindrical joints
+        if edge.is_cylindrical:
+            return self._add_cylindrical_joint_to_body(body, edge)
+
         joint_type = edge.mujoco_joint_type
         if joint_type is None:
             return None
@@ -434,8 +438,8 @@ class MuJoCoExporter:
         actuator_element = ET.SubElement(
             self.actuator,
             "position",
-            name=joint_element.get("name"),  # type: ignore
-            joint=joint_element.get("name"),  # type: ignore
+            name=joint_element.get("name"), # type: ignore
+            joint=joint_element.get("name"), # type: ignore
             kp="100",
         )
         if joint_range is not None:
@@ -445,10 +449,87 @@ class MuJoCoExporter:
         ET.SubElement(
             self.sensor,
             "jointpos",
-            name=joint_element.get("name") + "_pos",  # type: ignore
-            joint=joint_element.get("name"),  # type: ignore
+            name=joint_element.get("name") + "_pos", # type: ignore
+            joint=joint_element.get("name"), # type: ignore
         )
         return joint_element
+
+    def _add_cylindrical_joint_to_body(
+        self,
+        body: ET.Element,
+        edge: AssemblyGraphEdge,
+    ) -> ET.Element:
+        """Add both hinge and slide joints for a cylindrical joint.
+
+        A Cylindrical joint in FreeCAD combines rotation and translation
+        along the same axis. MuJoCo doesn't have a native cylindrical joint,
+        so we represent it as two joints on the same body:
+        1. A hinge joint for rotation
+        2. A slide joint for translation
+        Both share the same axis.
+        """
+        joint_pos_vector, joint_axis_vector = edge.joint_position_and_axis
+        joint_pos = " ".join(str(x) for x in joint_pos_vector)
+        joint_axis = " ".join(str(x) for x in joint_axis_vector)
+
+        # Create hinge joint for rotation
+        hinge_joint = ET.SubElement(
+            body,
+            "joint",
+            type="hinge",
+            name=f"{edge.label}_rotation",
+            pos=joint_pos,
+            axis=joint_axis,
+        )
+
+        # Create slide joint for translation
+        slide_joint = ET.SubElement(
+            body,
+            "joint",
+            type="slide",
+            name=f"{edge.label}_translation",
+            pos=joint_pos,
+            axis=joint_axis,
+        )
+
+        # Handle joint limits if present
+        # Note: Cylindrical joints may have separate limits for rotation and translation
+        joint_range = edge.joint_range
+        if joint_range is not None:
+            hinge_joint.set("range", joint_range)
+            # slide_joint would need separate translation limits if available
+
+        # Create actuators for both joints
+        ET.SubElement(
+            self.actuator,
+            "position",
+            name=f"{edge.label}_rotation",
+            joint=f"{edge.label}_rotation",
+            kp="100",
+        )
+        ET.SubElement(
+            self.actuator,
+            "position",
+            name=f"{edge.label}_translation",
+            joint=f"{edge.label}_translation",
+            kp="100",
+        )
+
+        # Create sensors for both joints
+        ET.SubElement(
+            self.sensor,
+            "jointpos",
+            name=f"{edge.label}_rotation_pos",
+            joint=f"{edge.label}_rotation",
+        )
+        ET.SubElement(
+            self.sensor,
+            "jointpos",
+            name=f"{edge.label}_translation_pos",
+            joint=f"{edge.label}_translation",
+        )
+
+        return hinge_joint  # Return primary joint
 
     def process_kinematic_loops(
         self,
@@ -469,6 +550,9 @@ class MuJoCoExporter:
                     solref="0.01 1",
                     solimp="0.9 0.95 0.001",
                 )
+            elif edge.is_cylindrical:
+                # Cylindrical joints in loops need special handling with dummy bodies
+                self._process_cylindrical_loop(u, v, edge)
             elif edge.mujoco_joint_type == "hinge":
                 joint_position, joint_axis = edge.joint_position_and_axis
                 offset_joint_position = joint_position + joint_axis.scale(
@@ -516,8 +600,8 @@ class MuJoCoExporter:
                     dummy_body,
                     "inertial",
                     pos=joint_pos,
-                    mass="1e-6",  # Much larger than mjMINVAL (1e-15)
-                    diaginertia="1e-9 1e-9 1e-9",  # Much larger than mjMINVAL
+                    mass="1e-6", # Much larger than mjMINVAL (1e-15)
+                    diaginertia="1e-9 1e-9 1e-9", # Much larger than mjMINVAL
                 )
                 # Insert joint between parent and dummy body
                 self.add_joint_to_body(dummy_body, edge)
@@ -527,11 +611,65 @@ class MuJoCoExporter:
                     self.equality,
                     "weld",
                     name=f"loop_weld_{edge.label}",
-                    body1=dummy_body.get("name"),  # type: ignore
+                    body1=dummy_body.get("name"), # type: ignore
                     body2=v.label,
                     solref="0.01 1",
                     solimp="0.9 0.95 0.001",
                 )
+
+    def _process_cylindrical_loop(
+        self,
+        u: AssemblyGraphNode,
+        v: AssemblyGraphNode,
+        edge: AssemblyGraphEdge,
+    ) -> None:
+        """Handle cylindrical joint in kinematic loop.
+
+        Creates a dummy body with both hinge and slide joints,
+        then connects it to the child body via weld constraint.
+        """
+        joint_pos_vector, joint_axis_vector = edge.joint_position_and_axis
+        joint_pos = " ".join(str(x) for x in joint_pos_vector)
+
+        # Find parent body
+        found_bodies = self.worldbody.findall(f".//body[@name='{u.label}']")
+        if not found_bodies:
+            raise ValueError(
+                f"Could not find body with name '{u.label}' in MJCF"
+            )
+
+        parent_body = found_bodies[0]
+
+        # Create dummy body for the cylindrical joint
+        dummy_body = ET.SubElement(
+            parent_body,
+            "body",
+            name=f"dummy_{u.label}_{v.label}",
+            pos=joint_pos,
+        )
+
+        # Add minimal inertia
+        ET.SubElement(
+            dummy_body,
+            "inertial",
+            pos=joint_pos,
+            mass="1e-6",  # Much larger than mjMINVAL (1e-15)
+            diaginertia="1e-9 1e-9 1e-9",  # Much larger than mjMINVAL
+        )
+
+        # Add both hinge and slide joints using the cylindrical handler
+        self._add_cylindrical_joint_to_body(dummy_body, edge)
+
+        # Connect dummy body to child via weld constraint
+        ET.SubElement(
+            self.equality,
+            "weld",
+            name=f"loop_weld_{edge.label}",
+            body1=dummy_body.get("name"),  # type: ignore
+            body2=v.label,
+            solref="0.01 1",
+            solimp="0.9 0.95 0.001",
+        )
 
     def write_xml(
         self,

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -637,7 +637,9 @@ class MuJoCoExporter:
                 # For other joint types we insert dummy bodies and add weld constraints
                 found_bodies = self.worldbody.findall(f".//body[@name='{u.label}']")
                 if not found_bodies:
-                    raise ValueError(f"Could not find body with name '{u.label}' in MJCF")
+                    raise ValueError(
+                        f"Could not find body with name '{u.label}' in MJCF"
+                    )
 
                 parent_body = found_bodies[0]
 
@@ -686,9 +688,7 @@ class MuJoCoExporter:
         # Find parent body
         found_bodies = self.worldbody.findall(f".//body[@name='{u.label}']")
         if not found_bodies:
-            raise ValueError(
-                f"Could not find body with name '{u.label}' in MJCF"
-            )
+            raise ValueError(f"Could not find body with name '{u.label}' in MJCF")
 
         parent_body = found_bodies[0]
 

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -663,15 +663,14 @@ class MuJoCoExporter:
                     diaginertia="1e-9 1e-9 1e-9",  # Much larger than mjMINVAL
                 )
                 # Insert joint between parent and dummy body
-# Insert joint between parent and dummy body
-if edge.is_ball:
-    # Ball joints in loops need special handling
-    self._process_ball_loop(u, v, edge)
-elif edge.is_cylindrical:
-    # Cylindrical joints in loops need special handling with dummy bodies
-    self._process_cylindrical_loop(u, v, edge)
-else:
-    self.add_joint_to_body(dummy_body, edge)
+                if edge.is_ball:
+                    # Ball joints in loops need special handling
+                    self._process_ball_loop(u, v, edge)
+                elif edge.is_cylindrical:
+                    # Cylindrical joints in loops need special handling with dummy bodies
+                    self._process_cylindrical_loop(u, v, edge)
+                else:
+                    self.add_joint_to_body(dummy_body, edge)
 
                 # Insert weld constraint between dummy body and child body
                 ET.SubElement(

--- a/tests/test_assembly_graph.py
+++ b/tests/test_assembly_graph.py
@@ -126,7 +126,7 @@ def test_cylindrical_joint_is_cylindrical_property(new_document_with_assembly: a
     cylinder_joint.JointType = "Cylindrical"
 
     edge = AssemblyGraphEdge(cylinder_joint, weight=1.0)
-    assert edge.is_cylindrical == True
+    assert edge.is_cylindrical
 
     # Create a revolute joint for comparison
     rev_joint = assembly.newObject("App::FeaturePython", "RevoluteJoint")
@@ -134,7 +134,7 @@ def test_cylindrical_joint_is_cylindrical_property(new_document_with_assembly: a
     rev_joint.JointType = "Revolute"
 
     rev_edge = AssemblyGraphEdge(rev_joint, weight=1.0)
-    assert rev_edge.is_cylindrical == False
+    assert not rev_edge.is_cylindrical
 
 
 def test_cylindrical_joint_position_and_axis(new_document_with_assembly: app.Document):
@@ -170,7 +170,7 @@ def test_ball_joint_is_ball_property(new_document_with_assembly: app.Document):
     ball_joint.JointType = "Ball"
 
     edge = AssemblyGraphEdge(ball_joint, weight=1.0)
-    assert edge.is_ball == True
+    assert edge.is_ball
 
     # Create a revolute joint for comparison
     rev_joint = assembly.newObject("App::FeaturePython", "RevoluteJoint")
@@ -178,7 +178,7 @@ def test_ball_joint_is_ball_property(new_document_with_assembly: app.Document):
     rev_joint.JointType = "Revolute"
 
     rev_edge = AssemblyGraphEdge(rev_joint, weight=1.0)
-    assert rev_edge.is_ball == False
+    assert not rev_edge.is_ball
 
 
 def test_ball_joint_position_and_axis(new_document_with_assembly: app.Document):

--- a/tests/test_assembly_graph.py
+++ b/tests/test_assembly_graph.py
@@ -116,7 +116,9 @@ def test_converting_graph_to_directed_tree(new_document_with_assembly: app.Docum
     assert len(unused_edges) == 1
 
 
-def test_cylindrical_joint_is_cylindrical_property(new_document_with_assembly: app.Document):
+def test_cylindrical_joint_is_cylindrical_property(
+    new_document_with_assembly: app.Document,
+):
     """Test that cylindrical joints are correctly identified."""
     assembly = new_document_with_assembly.Objects[0]
 

--- a/tests/test_assembly_graph.py
+++ b/tests/test_assembly_graph.py
@@ -114,3 +114,47 @@ def test_converting_graph_to_directed_tree(new_document_with_assembly: app.Docum
     assert len(tree.get_nodes()) == len(graph.get_nodes())
     assert len(tree.get_edges()) == len(graph.get_edges()) - 1
     assert len(unused_edges) == 1
+
+
+def test_cylindrical_joint_is_cylindrical_property(new_document_with_assembly: app.Document):
+    """Test that cylindrical joints are correctly identified."""
+    assembly = new_document_with_assembly.Objects[0]
+
+    # Create a cylindrical joint
+    cylinder_joint = assembly.newObject("App::FeaturePython", "CylindricalJoint")
+    JointObject.Joint(cylinder_joint, 0)
+    cylinder_joint.JointType = "Cylindrical"
+
+    edge = AssemblyGraphEdge(cylinder_joint, weight=1.0)
+    assert edge.is_cylindrical == True
+
+    # Create a revolute joint for comparison
+    rev_joint = assembly.newObject("App::FeaturePython", "RevoluteJoint")
+    JointObject.Joint(rev_joint, 0)
+    rev_joint.JointType = "Revolute"
+
+    rev_edge = AssemblyGraphEdge(rev_joint, weight=1.0)
+    assert rev_edge.is_cylindrical == False
+
+
+def test_cylindrical_joint_position_and_axis(new_document_with_assembly: app.Document):
+    """Test that cylindrical joints extract position and axis correctly."""
+    assembly = new_document_with_assembly.Objects[0]
+
+    # Create a cylindrical joint
+    cylinder_joint = assembly.newObject("App::FeaturePython", "CylindricalJoint")
+    JointObject.Joint(cylinder_joint, 0)
+    cylinder_joint.JointType = "Cylindrical"
+
+    # Set up basic placement
+    cylinder_joint.Placement1 = app.Placement()
+    cylinder_joint.Reference1 = None
+
+    edge = AssemblyGraphEdge(cylinder_joint, weight=1.0)
+
+    # Should not raise NotImplementedError
+    pos, axis = edge.joint_position_and_axis
+
+    assert isinstance(pos, app.Vector)
+    assert isinstance(axis, app.Vector)
+    assert abs(axis.Length - 1.0) < 1e-6  # Axis should be normalized

--- a/tests/test_assembly_graph.py
+++ b/tests/test_assembly_graph.py
@@ -158,3 +158,48 @@ def test_cylindrical_joint_position_and_axis(new_document_with_assembly: app.Doc
     assert isinstance(pos, app.Vector)
     assert isinstance(axis, app.Vector)
     assert abs(axis.Length - 1.0) < 1e-6  # Axis should be normalized
+
+
+def test_ball_joint_is_ball_property(new_document_with_assembly: app.Document):
+    """Test that ball joints are correctly identified."""
+    assembly = new_document_with_assembly.Objects[0]
+
+    # Create a ball joint
+    ball_joint = assembly.newObject("App::FeaturePython", "BallJoint")
+    JointObject.Joint(ball_joint, 0)
+    ball_joint.JointType = "Ball"
+
+    edge = AssemblyGraphEdge(ball_joint, weight=1.0)
+    assert edge.is_ball == True
+
+    # Create a revolute joint for comparison
+    rev_joint = assembly.newObject("App::FeaturePython", "RevoluteJoint")
+    JointObject.Joint(rev_joint, 0)
+    rev_joint.JointType = "Revolute"
+
+    rev_edge = AssemblyGraphEdge(rev_joint, weight=1.0)
+    assert rev_edge.is_ball == False
+
+
+def test_ball_joint_position_and_axis(new_document_with_assembly: app.Document):
+    """Test that ball joints extract position correctly (axis is zero vector)."""
+    assembly = new_document_with_assembly.Objects[0]
+
+    # Create a ball joint
+    ball_joint = assembly.newObject("App::FeaturePython", "BallJoint")
+    JointObject.Joint(ball_joint, 0)
+    ball_joint.JointType = "Ball"
+
+    # Set up basic placement
+    ball_joint.Placement1 = app.Placement()
+    ball_joint.Reference1 = None
+
+    edge = AssemblyGraphEdge(ball_joint, weight=1.0)
+
+    # Should not raise NotImplementedError
+    pos, axis = edge.joint_position_and_axis
+
+    assert isinstance(pos, app.Vector)
+    assert isinstance(axis, app.Vector)
+    # Ball joints return zero vector for axis (not needed for ball joints)
+    assert abs(axis.Length) < 1e-6


### PR DESCRIPTION
Add support for cylindrical joints

Implement cylindrical joint support by representing them as a combination
of hinge and slide joints sharing the same axis, since MuJoCo lacks native
cylindrical joint support.


- Add cylindrical joint handling in AssemblyGraphEdge for axis extraction
- Add is_cylindrical property for joint type detection
- Create _add_cylindrical_joint_to_body for dual joint generation
- Add _process_cylindrical_loop for kinematic loop handling
- Update README to mark cylindrical joint support as implemented
- Add unit tests for cylindrical joint properties and axis extraction

Test Object : 

<img width="1122" height="758" alt="image" src="https://github.com/user-attachments/assets/3ed2cf25-2489-4858-98c2-97bd19d18af0" />


![Recording 2026-03-11 172039](https://github.com/user-attachments/assets/df8119c6-2872-457b-8675-fc8fcc345a98)
