### PR TITLE
Fix depth first traversal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,14 +32,14 @@ jobs:
     name: Lint and format code
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Setup Environment
       uses: ./.github/actions/environment
       with:
         python_version: ${{ env.PYTHON_VERSION }}
         freecad_version: ${{ env.FREECAD_VERSION }}
     - name: Cache pre-commit environments
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
     hooks:
     - id: mypy
       types_or: [file, python]
-      files: .*\.(FCMacro|py)$
+      files: freecad/.*\.(FCMacro|py)$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Set `align="true"` property of MuJoCo [freejoint](https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-freejoint) ([#15](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/15))
+
+
+### Fixed
+
+- Fix depth first traversal of graph ([#15](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/15))
+
+
 ## [0.3.0](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/releases/tag/v0.3.0) - 2025-11-18
 
 ### Added

--- a/freecad/assembly2mujoco/core/assembly.py
+++ b/freecad/assembly2mujoco/core/assembly.py
@@ -226,6 +226,7 @@ class AssemblyGraph:
 
         # Then get all disconnected parts that are still part of the assembly
         for object in assembly.OutList:
+            # TODO: Handle other cases
             if object.TypeId == "PartDesign::Body" or UtilsAssembly.isLink(object):
                 node = AssemblyGraphNode(
                     object, is_grounded=assembly.isPartGrounded(object)

--- a/freecad/assembly2mujoco/core/graph_utils.py
+++ b/freecad/assembly2mujoco/core/graph_utils.py
@@ -16,7 +16,9 @@ __all__ = ["depth_first_traversal", "get_disconnected_subgraphs"]
 def depth_first_traversal(
     graph: AssemblyGraph, *, root_node: AssemblyGraphNode
 ) -> Generator[
-    tuple[AssemblyGraphNode, AssemblyGraphNode, AssemblyGraphEdge], None, None
+    tuple[AssemblyGraphNode, AssemblyGraphNode | None, AssemblyGraphEdge | None],
+    None,
+    None,
 ]:
     seen_edges: set[AssemblyGraphEdge] = set()
     queue: Queue[AssemblyGraphNode] = Queue()
@@ -25,7 +27,12 @@ def depth_first_traversal(
     while not queue.empty():
         current_node = queue.get()
 
-        for next_node in graph.get_neighbors(current_node):
+        current_node_neighbors = graph.get_neighbors(current_node)
+        if len(current_node_neighbors) == 0:
+            yield current_node, None, None
+            continue
+
+        for next_node in current_node_neighbors:
             edge = graph.get_edge(current_node, next_node)
             if edge in seen_edges:
                 continue
@@ -56,10 +63,15 @@ def get_disconnected_subgraphs(graph: AssemblyGraph) -> list["AssemblyGraph"]:
         ):
             if current_node in remaining_nodes:
                 remaining_nodes.remove(current_node)
+            subgraph.add_node(current_node)
+
+            if next_node is None or edge is None:
+                continue
+
             if next_node in remaining_nodes:
                 remaining_nodes.remove(next_node)
-            subgraph.add_node(current_node)
             subgraph.add_node(next_node)
+
             subgraph.add_edge(edge=edge, parent_node=current_node, child_node=next_node)
 
         subgraphs.append(subgraph)
@@ -143,6 +155,9 @@ def convert_to_directed_tree(
         tree, root_node=root_node
     ):
         directed_tree.add_node(parent_node)
+        if child_node is None or edge is None:
+            continue
+
         directed_tree.add_node(child_node)
         directed_tree.add_edge(edge, parent_node=parent_node, child_node=child_node)
 

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -404,10 +404,8 @@ class MuJoCoExporter:
         self,
         body: ET.Element,
     ) -> ET.Element:
-        joint_element = ET.SubElement(
-            body,
-            "freejoint",
-        )
+        # TODO: Check whether align="true" is always the right choice
+        joint_element = ET.SubElement(body, "freejoint", align="true")
         return joint_element
 
     def add_joint_to_body(

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -188,6 +188,10 @@ class MuJoCoExporter:
 
         self.worldbody.append(ET.Comment("Assembly"))
         for graph in assembly_subgraphs:
+            if len(graph.get_nodes()) == 0:
+                log_message("Subgraph is empty. This should not happen")
+                raise RuntimeError("Subgraph is empty")
+
             # Handle graphs with a single node
             if len(graph.get_nodes()) == 1:
                 self.process_single_node_tree(graph, self.worldbody)
@@ -328,6 +332,9 @@ class MuJoCoExporter:
             if (parent_body := body_elements.get(parent_node)) is None:
                 parent_body = self.add_body(parent_node, worldbody)
                 body_elements[parent_node] = parent_body
+
+            if child_node is None or edge is None:
+                continue
 
             if (child_body := body_elements.get(child_node)) is None:
                 child_body = self.add_body(child_node, parent_body)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ requires = ["setuptools >= 77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]
+exclude = ["tests/"]
 explicit_package_bases = true
 ignore_missing_imports = true
 

--- a/tests/test_assembly_graph.py
+++ b/tests/test_assembly_graph.py
@@ -86,6 +86,30 @@ def test_depth_first_traversal(new_document_with_assembly: app.Document):
     assert traversed_edges == set(edges)
 
 
+def test_depth_first_traversal_single_node(new_document_with_assembly: app.Document):
+    graph = AssemblyGraph()
+
+    node = AssemblyGraphNode(
+        new_document_with_assembly.addObject("PartDesign::Body", "Body")
+    )
+    graph.add_node(node)
+    nodes = [node]
+
+    traversed_nodes = set()
+    traversed_edges = set()
+    for current_node, next_node, edge in depth_first_traversal(
+        graph, root_node=nodes[0]
+    ):
+        traversed_nodes.add(current_node)
+        if next_node is None:
+            continue
+        traversed_nodes.add(next_node)
+        traversed_edges.add(edge)
+
+    assert traversed_nodes == set(nodes)
+    assert traversed_edges == set()
+
+
 def test_converting_graph_to_directed_tree(new_document_with_assembly: app.Document):
     graph = AssemblyGraph()
 


### PR DESCRIPTION
This PR fixes depth first traversal and related code to handle the case when the graph contains a single node.

It additionally sets the `align="true"` property of joints of type [freejoint](https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-freejoint) to align the center of the joint with the center of the body.