### PR TITLE
Add site to exported bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Handle conversion of cylindrical and ball joints ([#14](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/14))
+- Add invisible [site](https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-site) element to each exported body ([#17](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/17))
 
 ### Changed
 

--- a/freecad/assembly2mujoco/core/assembly.py
+++ b/freecad/assembly2mujoco/core/assembly.py
@@ -45,8 +45,24 @@ class AssemblyGraphNode:
         super().__init__()
         self.part = part
         self.is_grounded = is_grounded
+        # We position the node in MuJoCo at the origin.
+        # The corresponding exported mesh will have the actual position information.
         self.pos = "0 0 0"
         self.quat = "1.0 0.0 0.0 0.0"
+
+    @property
+    def absolute_position(self) -> tuple[str, str]:
+        """Get absolute position of body.
+
+        This is used for position MuJoCo site tags.
+        """
+        # Use global position and orientation
+        pos = self.part.Placement.Base
+        quat = self.part.Placement.Rotation.Q
+        # Convert mm to m and convert both vectors to strings
+        pos = f"{pos.x / 1000} {pos.y / 1000} {pos.z / 1000}"
+        quat = f"{quat[0]} {quat[1]} {quat[2]} {quat[3]}"
+        return pos, quat
 
     @property
     def body_appearance(self) -> AppearanceDict:

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -398,6 +398,11 @@ class MuJoCoExporter:
             contype="0",
             conaffinity="0",
         )
+        # Add invisible site to body for potential use in mounting sensors
+        pos, quat = node.absolute_position
+        ET.SubElement(
+            body, "site", name=f"{node.label} site", pos=pos, quat=quat, rgba="0 0 0 0"
+        )
         return body
 
     def add_free_joint_to_body(


### PR DESCRIPTION
This PR adds a [site](https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-site) element to each body in the exported MuJoCo model. This can be used to mount sensors, for example.