### PR TITLE
Allow disabling sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Handle conversion of cylindrical and ball joints ([#14](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/14))
 - Add invisible [site](https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-site) element to each exported body ([#17](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/17))
+- Allow users to disable adding sites to exported bodies ([#18](https://github.com/AnesBenmerzoug/FreeCAD-Assembly2MuJoCo/pull/18))
 
 ### Changed
 

--- a/freecad/assembly2mujoco/constants.py
+++ b/freecad/assembly2mujoco/constants.py
@@ -42,6 +42,7 @@ DEFAULT_MJCF_INTEGRATOR: Literal["Euler", "implicit", "implicitfast", "RK4"] = (
 DEFAULT_MJCF_SOLVER: Literal["PGS", "CG", "Newton"] = "Newton"
 DEFAULT_MJCF_SOLVER_MAX_ITERATIONS: float = 200
 DEFAULT_MJCF_SOLVER_TOLERANCE: float = 1e-10
+DEFAULT_MJCF_ADD_SITES: bool = True
 
 # Assign weights to prioritize which joints to keep in the tree
 # Higher weight are more likely to be excluded from tree

--- a/freecad/assembly2mujoco/core/mujoco.py
+++ b/freecad/assembly2mujoco/core/mujoco.py
@@ -18,6 +18,7 @@ from freecad.assembly2mujoco.constants import (
     DEFAULT_MJCF_TIMESTEP,
     DEFAULT_MJCF_ARMATURE,
     DEFAULT_MJCF_DAMPING,
+    DEFAULT_MJCF_ADD_SITES,
     WORKBENCH_NAME,
 )
 from freecad.assembly2mujoco.core.assembly import (
@@ -62,6 +63,7 @@ class MuJoCoExporter:
         mjcf_timestep: float = DEFAULT_MJCF_TIMESTEP,
         mjcf_damping: float = DEFAULT_MJCF_DAMPING,
         mjcf_armature: float = DEFAULT_MJCF_ARMATURE,
+        mjcf_add_sites: bool = DEFAULT_MJCF_ADD_SITES,
     ) -> None:
         self.mesh_export_format = mesh_export_format
         self.stl_mesh_linear_deflection = stl_mesh_linear_deflection
@@ -74,6 +76,7 @@ class MuJoCoExporter:
         self.mjcf_timestep = mjcf_timestep
         self.mjcf_damping = mjcf_damping
         self.mjcf_armature = mjcf_armature
+        self.mjcf_add_sites = mjcf_add_sites
 
         self.mujoco = ET.Element("mujoco")
         self.option = ET.SubElement(
@@ -398,11 +401,17 @@ class MuJoCoExporter:
             contype="0",
             conaffinity="0",
         )
-        # Add invisible site to body for potential use in mounting sensors
-        pos, quat = node.absolute_position
-        ET.SubElement(
-            body, "site", name=f"{node.label} site", pos=pos, quat=quat, rgba="0 0 0 0"
-        )
+        if self.mjcf_add_sites:
+            # Add invisible site to body for potential use in mounting sensors
+            pos, quat = node.absolute_position
+            ET.SubElement(
+                body,
+                "site",
+                name=f"{node.label} site",
+                pos=pos,
+                quat=quat,
+                rgba="0 0 0 0",
+            )
         return body
 
     def add_free_joint_to_body(

--- a/freecad/assembly2mujoco/ui/mjcf_options_editor.py
+++ b/freecad/assembly2mujoco/ui/mjcf_options_editor.py
@@ -8,6 +8,7 @@ from freecad.assembly2mujoco.constants import (
     DEFAULT_MJCF_TIMESTEP,
     DEFAULT_MJCF_INTEGRATOR,
     DEFAULT_MJCF_SOLVER,
+    DEFAULT_MJCF_ADD_SITES,
 )
 
 __all__ = ["MJCFOptionsEditor"]
@@ -56,6 +57,16 @@ class MJCFOptionsEditor(QtWidgets.QWidget):
         self.solver_combo.addItems(solver_values)
         form_layout.addRow("Solver:", self.solver_combo)
 
+        # Sites
+        self.site_check = QtWidgets.QCheckBox()
+        self.site_check.setCheckState(
+            QtCore.Qt.CheckState.Checked
+            if DEFAULT_MJCF_ADD_SITES
+            else QtCore.Qt.CheckState.Unchecked
+        )
+        self.site_check.setToolTip("Add a site to each body")
+        form_layout.addRow("Sites:", self.site_check)
+
         # Reset button
         reset_button = QtWidgets.QPushButton("Reset to Defaults")
         reset_button.clicked.connect(self.reset_to_defaults)
@@ -68,6 +79,7 @@ class MJCFOptionsEditor(QtWidgets.QWidget):
             mjcf_armature=self.armature_spin.value(),
             mjcf_integrator=self.integrator_combo.currentText(),
             mjcf_solver=self.solver_combo.currentText(),
+            mjcf_add_sites=self.site_check.isChecked(),
         )
         return options
 
@@ -77,3 +89,8 @@ class MJCFOptionsEditor(QtWidgets.QWidget):
         self.armature_spin.setValue(DEFAULT_MJCF_ARMATURE)
         self.integrator_combo.setCurrentText(DEFAULT_MJCF_INTEGRATOR)
         self.solver_combo.setCurrentText(DEFAULT_MJCF_SOLVER)
+        self.site_check.setCheckState(
+            QtCore.Qt.CheckState.Checked
+            if DEFAULT_MJCF_ADD_SITES
+            else QtCore.Qt.CheckState.Unchecked
+        )

--- a/scripts/03_run_tests.sh
+++ b/scripts/03_run_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xeuo pipefail
+set -euo pipefail
 
 # Log helper that writes to stderr so it doesn't interfere with stdout data capture needed for CI
 log() { echo -e "$*" >&2; }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,18 @@ def crank_and_slider_assembly(examples_dir: Path) -> app.DocumentObject:
     yield assemblies[0]
 
 
+@pytest.fixture(scope="session")
+def pan_tilt_assembly(examples_dir: Path) -> app.DocumentObject:
+    assembly_file = examples_dir / "pan_tilt" / "pan_tilt.FCStd"
+    assert assembly_file.is_file()
+    document = app.openDocument(os.fspath(assembly_file))
+    assemblies = list(
+        filter(lambda x: x.TypeId == "Assembly::AssemblyObject", document.Objects)
+    )
+    assert len(assemblies) == 1
+    yield assemblies[0]
+
+
 @pytest.fixture
 def new_document() -> app.Document:
     return app.newDocument()

--- a/tests/test_assembly_graph.py
+++ b/tests/test_assembly_graph.py
@@ -15,7 +15,8 @@ from pytest import FixtureRequest
 
 
 @pytest.mark.parametrize(
-    "assembly_fixture_name", ["universal_joint_assembly", "crank_and_slider_assembly"]
+    "assembly_fixture_name",
+    ["universal_joint_assembly", "crank_and_slider_assembly", "pan_tilt_assembly"],
 )
 def test_assembly_graph(request: FixtureRequest, assembly_fixture_name: str):
     assembly: app.DocumentObject = request.getfixturevalue(assembly_fixture_name)

--- a/tests/test_mujoco_export.py
+++ b/tests/test_mujoco_export.py
@@ -9,14 +9,19 @@ from freecad.assembly2mujoco.core.mujoco import MuJoCoExporter
 
 
 @pytest.mark.parametrize(
-    "assembly_fixture_name", ["universal_joint_assembly", "crank_and_slider_assembly"]
+    "assembly_fixture_name",
+    ["universal_joint_assembly", "crank_and_slider_assembly", "pan_tilt_assembly"],
 )
+@pytest.mark.parametrize("mjcf_add_sites", [True, False])
 def test_mujoco_export(
-    request: FixtureRequest, tmp_path: Path, assembly_fixture_name: str
+    request: FixtureRequest,
+    tmp_path: Path,
+    assembly_fixture_name: str,
+    mjcf_add_sites: bool,
 ):
     assembly: app.DocumentObject = request.getfixturevalue(assembly_fixture_name)
     graph = AssemblyGraph.from_assembly(assembly)
-    exporter = MuJoCoExporter()
+    exporter = MuJoCoExporter(mjcf_add_sites=mjcf_add_sites)
     mujoco_xml = exporter.export_assembly(graph)
     assert len(mujoco_xml.findall("*")) > 0
     worldbody = mujoco_xml.find("worldbody")


### PR DESCRIPTION
This PR adds a checkbox to allow disabling adding sites to exported bodies. 

It also parametrizes tests to run with and without adding sites to exported bodies and adds the pan tilt assembly to the tests.